### PR TITLE
Fix GitHub field

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 name:                confcrypt
 version:             0.1.0.4
-github:              "https://github.com/collegevine/confcrypt"
+github:              collegevine/confcrypt
 license:             MIT
 author:              "Chris Coffey"
 maintainer:          "chris@collegevine.com"


### PR DESCRIPTION
The current `package.yaml` is generating a Cabal file with links to the repository as `https://github.com/https://github.com/collegevine/confcrypt`.