### PR TITLE
Teach read the --format option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ confcrypt.cabal
 /tmp
 test.econf
 testk.econf
+.vscode

--- a/app/ConfCrypt/CLI/API.hs
+++ b/app/ConfCrypt/CLI/API.hs
@@ -8,13 +8,15 @@ module ConfCrypt.CLI.API (
 ) where
 
 import ConfCrypt.Types (SchemaType(..))
-import ConfCrypt.Commands (GetConfCrypt(..), AddConfCrypt(..), EditConfCrypt(..), DeleteConfCrypt(..))
+import ConfCrypt.Commands (GetConfCrypt(..), AddConfCrypt(..), EditConfCrypt(..), DeleteConfCrypt(..), ReadConfCrypt(..))
 
-import Options.Applicative (ParserInfo, Parser, progDesc, command, fullDesc, long, flag, metavar,
-    help, strOption, short, info, header, footer, strArgument, hsubparser, helper, (<**>))
+import Options.Applicative (ParserInfo, Parser, progDesc, command, fullDesc, long, flag, metavar, maybeReader,
+    help, strOption, short, info, header, footer, strArgument, hsubparser, helper, (<**>), value, option, auto)
 import qualified Data.Text as T
 import Paths_confcrypt (version)
 import Data.Version (showVersion)
+import Options.Applicative (ReadM)
+import Text.Read (readMaybe)
 
 data KeyAndConf = KeyAndConf {key :: ParsedKey, provider :: KeyProvider, conf :: FilePath}
     deriving (Eq, Show)
@@ -22,7 +24,7 @@ newtype Conf = Conf FilePath
     deriving (Eq, Show)
 
 data AnyCommand
-    = RC KeyAndConf
+    = RC KeyAndConf ReadConfCrypt
     | GC KeyAndConf GetConfCrypt
     | AC KeyAndConf AddConfCrypt
     | EC KeyAndConf EditConfCrypt
@@ -125,7 +127,7 @@ delete = info ( DC <$> getConf <*> (DeleteConfCrypt <$> onlyName))
 readConf ::
     KeyProvider
     -> ParserInfo AnyCommand
-readConf provider = info ( RC <$> keyAndConf provider False)
+readConf provider = info ( RC <$> keyAndConf provider False <*> (ReadConfCrypt <$> onlyFormat))
            (progDesc "Read in the provided config and decrypt it with the key. Results are printed to StdOut." <>
             fullDesc)
 
@@ -208,3 +210,19 @@ onlyType =
         )
     where
         fromString = read . (:) 'C'
+
+onlyFormat :: Parser (Maybe T.Text)
+onlyFormat = option maybeOptReader (
+    long "format" <>
+    short 'f' <>
+    metavar "TEMPLATE" <>
+    value Nothing <>
+    help (
+        "Output parameters in a custom format specified by a template, with placeholders being replaced " <>
+        "with the values for each parameter. Placeholders consist of a '%' and a single character, " <>
+        "a literal '%' can be written as '%%'. Valid placeholders are: %t: type, %n: name, %v: value."
+        )
+    )
+
+maybeOptReader :: ReadM (Maybe T.Text)
+maybeOptReader = maybeReader $ Just. Just . T.pack

--- a/app/ConfCrypt/CLI/API.hs
+++ b/app/ConfCrypt/CLI/API.hs
@@ -10,12 +10,14 @@ module ConfCrypt.CLI.API (
 import ConfCrypt.Types (SchemaType(..))
 import ConfCrypt.Commands (GetConfCrypt(..), AddConfCrypt(..), EditConfCrypt(..), DeleteConfCrypt(..), ReadConfCrypt(..))
 
-import Options.Applicative (ParserInfo, Parser, progDesc, command, fullDesc, long, flag, metavar, maybeReader,
-    help, strOption, short, info, header, footer, strArgument, hsubparser, helper, (<**>), value, option, auto)
+import Options.Applicative
+       (ParserInfo, Parser, progDesc, command, fullDesc, long, flag,
+        metavar, maybeReader, help, strOption, short, info, header, footer,
+        strArgument, hsubparser, helper, (<**>), value, option, auto,
+        ReadM)
 import qualified Data.Text as T
 import Paths_confcrypt (version)
 import Data.Version (showVersion)
-import Options.Applicative (ReadM)
 import Text.Read (readMaybe)
 
 data KeyAndConf = KeyAndConf {key :: ParsedKey, provider :: KeyProvider, conf :: FilePath}

--- a/app/ConfCrypt/CLI/Engine.hs
+++ b/app/ConfCrypt/CLI/Engine.hs
@@ -47,8 +47,8 @@ run parsedArguments = do
             result <- case parsedArguments of
 
                 -- Requires Decryption
-                RC KeyAndConf {key, provider} ->
-                    runConfCrypt parsedConfiguration $ runWithDecrypt key provider ReadConfCrypt
+                RC KeyAndConf {key, provider} cmd ->
+                    runConfCrypt parsedConfiguration $ runWithDecrypt key provider cmd
                 GC KeyAndConf {key, provider} cmd ->
                     runConfCrypt parsedConfiguration $ runWithDecrypt key provider cmd
                 VC KeyAndConf {key, provider} ->
@@ -107,7 +107,7 @@ runConfCrypt file action =
     runResourceT . runExceptT $ runReaderT action (file, ())
 
 confFilePath :: AnyCommand -> FilePath
-confFilePath  (RC KeyAndConf {conf}) = conf
+confFilePath  (RC KeyAndConf {conf} _) = conf
 confFilePath  (GC KeyAndConf {conf} _) = conf
 confFilePath  (VC KeyAndConf {conf}) = conf
 confFilePath  (AC KeyAndConf {conf} _) = conf

--- a/package.yaml
+++ b/package.yaml
@@ -52,6 +52,7 @@ library:
     - ConfCrypt.Validation
     - ConfCrypt.Default
     - ConfCrypt.Providers.AWS
+    - ConfCrypt.Template
   default-extensions: MultiParamTypeClasses OverloadedStrings FlexibleContexts FlexibleInstances NamedFieldPuns
         TupleSections DeriveGeneric DeriveAnyClass FunctionalDependencies TypeApplications UndecidableInstances
         GADTs ConstraintKinds

--- a/src/ConfCrypt/Commands.hs
+++ b/src/ConfCrypt/Commands.hs
@@ -67,9 +67,9 @@ instance (Monad m, MonadDecrypt (ConfCryptM m key) key) => Command ReadConfCrypt
                 pure $ renderTemplate tpl <$> params'
 
         where
-            decryptParam ctx (Parameter paramName value paramType) = do
-                value' <- decryptValue ctx value
-                pure $ Parameter {paramName, paramValue = value', paramType}
+            decryptParam ctx param = do
+                value' <- decryptValue ctx $ paramValue param
+                pure param {paramValue = value'}
 
             decryptedParam param v = ParameterLine ParamLine {pName = paramName param, pValue = v}
 

--- a/src/ConfCrypt/Commands.hs
+++ b/src/ConfCrypt/Commands.hs
@@ -62,9 +62,12 @@ instance (Monad m, MonadDecrypt (ConfCryptM m key) key) => Command ReadConfCrypt
             Nothing -> do
                 transformed <- mapM (\p -> decryptedParam p <$> decryptValue ctx (paramValue p)) params
                 processReadLines transformed ccFile
-            Just tpl -> do
-                params' <- sequence $ decryptParam ctx <$> params
-                pure $ renderTemplate tpl <$> params'
+            Just tpl ->
+                case renderTemplate tpl of
+                    Left e -> pure ["" :: T.Text] -- how to return an error from here?
+                    Right parsedTpl -> do
+                        params' <- sequence $ decryptParam ctx <$> params
+                        pure $ parsedTpl <$> params'
 
         where
             decryptParam ctx param = do

--- a/src/ConfCrypt/Commands.hs
+++ b/src/ConfCrypt/Commands.hs
@@ -64,7 +64,7 @@ instance (Monad m, MonadDecrypt (ConfCryptM m key) key) => Command ReadConfCrypt
                 processReadLines transformed ccFile
             Just tpl ->
                 case renderTemplate tpl of
-                    Left e -> pure ["" :: T.Text] -- how to return an error from here?
+                    Left e -> throwError $ FormatParseError e
                     Right parsedTpl -> do
                         params' <- sequence $ decryptParam ctx <$> params
                         pure $ parsedTpl <$> params'

--- a/src/ConfCrypt/Template.hs
+++ b/src/ConfCrypt/Template.hs
@@ -16,9 +16,9 @@ import Text.Megaparsec.Error (errorBundlePretty)
 -- %[a-z] %x %y %z
 
 
-renderTemplate :: Text -> Either TemplateParseError (Parameter -> Text)
+renderTemplate :: Text -> Either Text (Parameter -> Text)
 renderTemplate template = case parse parseTemplate "" template of
-    Left err -> Left . TemplateParseError . pack $ show err
+    Left err -> Left . pack $ show err
     Right parsed -> Right (\param -> foldMap (replaceVars param) parsed)
     where
         replaceVars p (Text_ t)         = t

--- a/src/ConfCrypt/Template.hs
+++ b/src/ConfCrypt/Template.hs
@@ -9,12 +9,6 @@ import Data.Text (Text, pack)
 import Text.Megaparsec (Parsec, (<|>), anySingle, try, noneOf, many, some, parse, errorBundlePretty, ShowErrorComponent)
 import Text.Megaparsec.Char (string')
 
--- "text %k=%v %%"
--- "text foo=bar %"
--- ["text ", k, "=", v, " %"]
--- %[a-z] %x %y %z
-
-
 renderTemplate :: Text -> Either Text (Parameter -> Text)
 renderTemplate template = case parse parseTemplate "" template of
     Left err -> Left . pack $ errorBundlePretty err
@@ -28,8 +22,6 @@ renderTemplate template = case parse parseTemplate "" template of
 
 type Parser = Parsec TemplateParseError Text
 newtype TemplateParseError = TemplateParseError Text deriving (Show, Ord, Eq, ShowErrorComponent)
-
--- type Parser = Parsec ParseError Text
 
 parseTemplate :: Parser [Template]
 parseTemplate =

--- a/src/ConfCrypt/Template.hs
+++ b/src/ConfCrypt/Template.hs
@@ -6,9 +6,8 @@ import ConfCrypt.Types (Parameter(..), typeToOutputString)
 import Control.Monad (void)
 import Data.Maybe (maybe)
 import Data.Text (Text, pack)
-import Text.Megaparsec (Parsec, (<|>), anySingle, try, noneOf, many, some, parse)
+import Text.Megaparsec (Parsec, (<|>), anySingle, try, noneOf, many, some, parse, errorBundlePretty, ShowErrorComponent)
 import Text.Megaparsec.Char (string')
-import Text.Megaparsec.Error (errorBundlePretty)
 
 -- "text %k=%v %%"
 -- "text foo=bar %"
@@ -18,7 +17,7 @@ import Text.Megaparsec.Error (errorBundlePretty)
 
 renderTemplate :: Text -> Either Text (Parameter -> Text)
 renderTemplate template = case parse parseTemplate "" template of
-    Left err -> Left . pack $ show err
+    Left err -> Left . pack $ errorBundlePretty err
     Right parsed -> Right (\param -> foldMap (replaceVars param) parsed)
     where
         replaceVars p (Text_ t)         = t
@@ -28,7 +27,7 @@ renderTemplate template = case parse parseTemplate "" template of
 
 
 type Parser = Parsec TemplateParseError Text
-newtype TemplateParseError = TemplateParseError Text deriving (Show, Ord, Eq)
+newtype TemplateParseError = TemplateParseError Text deriving (Show, Ord, Eq, ShowErrorComponent)
 
 -- type Parser = Parsec ParseError Text
 

--- a/src/ConfCrypt/Template.hs
+++ b/src/ConfCrypt/Template.hs
@@ -1,0 +1,70 @@
+module ConfCrypt.Template (
+    renderTemplate
+    ) where
+
+import Text.Megaparsec
+import Text.Megaparsec.Char
+import Data.Text
+import ConfCrypt.Types (Parameter(..))
+import qualified Data.Text as T
+
+-- "text %k=%v %%"
+-- "text foo=bar %"
+-- ["text ", k, "=", v, " %"]
+-- %[a-z] %x %y %z
+
+
+renderTemplate :: Text -> Parameter -> Text
+renderTemplate template param = case parse parseTemplate "" template of
+    Left err -> pack . show $ err
+    Right parsed -> foldMap replaceVars parsed
+    where
+        replaceVars (Text_ t)         = t
+        replaceVars (Variable_ Name)  = paramName param
+        replaceVars (Variable_ Value) = paramValue param
+        replaceVars (Variable_ Type)  = T.pack . show . paramType $ param
+
+
+type Parser = Parsec MyParseError Text
+type ApplyTemplate = Text -> Text -> Text -> Text
+newtype MyParseError = MyParseError Text deriving (Show, Ord, Eq)
+
+-- type Parser = Parsec ParseError Text
+
+parseTemplate :: Parser [Template]
+parseTemplate =
+    many (txt <|> var)
+    where
+        var = Variable_ <$> parseVariable
+        txt = Text_ <$> parseLiteral
+
+data Template = Variable_ Variable | Text_ Text
+    deriving Show
+
+parseLiteral :: Parser Text
+parseLiteral = let
+    escapedPercent = do
+        _ <- try $ string' "%%"
+        pure "%"
+    otherText = pack <$> some (noneOf ['%'])
+    in escapedPercent <|> otherText
+
+
+data Variable = Name | Value | Type deriving Show
+
+parseVariable :: Parser Variable
+parseVariable = let
+    tryName = do
+        _ <- try $ string' "%n"
+        pure Name
+    tryVal = do
+        _ <- try $ string' "%v"
+        pure Value
+    tryType = do
+        _ <- try $ string' "%t"
+        pure Type
+    unrecognized = do
+        _ <- string' "%"
+        invalid <- anySingle
+        fail $ "Unrecognized variable " ++ [invalid]
+    in tryName <|> tryVal <|> tryType <|> unrecognized

--- a/src/ConfCrypt/Types.hs
+++ b/src/ConfCrypt/Types.hs
@@ -66,6 +66,7 @@ data ConfCryptError
     | UnknownParameter T.Text
     | WrongFileAction T.Text
     | CleanupError T.Text
+    | FormatParseError T.Text
     deriving (Generic, Eq, Ord)
 
 instance Show ConfCryptError where
@@ -80,11 +81,11 @@ instance Show ConfCryptError where
     show (UnknownParameter msg) = "UnknownParameter: "<> T.unpack msg
     show (WrongFileAction msg) = "WrongFileAction: "<> T.unpack msg
     show (CleanupError msg) = "CleanupError: "<> T.unpack msg
+    show (FormatParseError msg) = "Format parse error: "<> T.unpack msg
 
 instance ShowErrorComponent ConfCryptError where
     showErrorComponent (ParserError msg) = T.unpack msg
     showErrorComponent _ = "Not a parsable error"
-
 
 instance Ord RSA.Error where
     (<=) l r = show l <= show r

--- a/test/ConfCrypt/CLI/API/Tests.hs
+++ b/test/ConfCrypt/CLI/API/Tests.hs
@@ -3,7 +3,7 @@ module ConfCrypt.CLI.API.Tests (
     ) where
 
 import ConfCrypt.CLI.API
-import ConfCrypt.Commands (GetConfCrypt(..), AddConfCrypt(..), EditConfCrypt(..), DeleteConfCrypt(..))
+import ConfCrypt.Commands (GetConfCrypt(..), AddConfCrypt(..), EditConfCrypt(..), DeleteConfCrypt(..), ReadConfCrypt(..))
 import ConfCrypt.Types
 
 import ConfCrypt.Common
@@ -59,6 +59,14 @@ readCases = testGroup "read" [
             res = execParserPure defaultPrefs cliParser args
         case res of
             Success (RC (KeyAndConf (OnDisk "testKey") LocalRSA "test.econf") _) -> assertBool "can't fail" True
+            Success a -> assertFailure ("Incorrectly parsed: "<> show a)
+            Failure _ -> assertFailure "Should have parsed an RC"
+            CompletionInvoked _ -> assertFailure "Incorrectly triggered completion"
+    ,testCase "read preserves the provided key file with --key" $ do
+        let args = ["rsa", "read", "--key", "testKey","test.econf", "--format", "foo"]
+            res = execParserPure defaultPrefs cliParser args
+        case res of
+            Success (RC (KeyAndConf (OnDisk "testKey") LocalRSA "test.econf") (ReadConfCrypt (Just "foo"))) -> assertBool "can't fail" True
             Success a -> assertFailure ("Incorrectly parsed: "<> show a)
             Failure _ -> assertFailure "Should have parsed an RC"
             CompletionInvoked _ -> assertFailure "Incorrectly triggered completion"

--- a/test/ConfCrypt/CLI/API/Tests.hs
+++ b/test/ConfCrypt/CLI/API/Tests.hs
@@ -50,7 +50,7 @@ readCases = testGroup "read" [
         let args = ["rsa", "read", "-k", "testKey", "test.econf"]
             res = execParserPure defaultPrefs cliParser args
         case res of
-            Success (RC (KeyAndConf (OnDisk "testKey") LocalRSA "test.econf") ) -> assertBool "can't fail" True
+            Success (RC (KeyAndConf (OnDisk "testKey") LocalRSA "test.econf") _) -> assertBool "can't fail" True
             Success a -> assertFailure ("Incorrectly parsed: "<> show a)
             Failure _ -> assertFailure "Should have parsed an RC"
             CompletionInvoked _ -> assertFailure "Incorrectly triggered completion"
@@ -58,7 +58,7 @@ readCases = testGroup "read" [
         let args = ["rsa", "read", "--key", "testKey","test.econf"]
             res = execParserPure defaultPrefs cliParser args
         case res of
-            Success (RC (KeyAndConf (OnDisk "testKey") LocalRSA "test.econf") ) -> assertBool "can't fail" True
+            Success (RC (KeyAndConf (OnDisk "testKey") LocalRSA "test.econf") _) -> assertBool "can't fail" True
             Success a -> assertFailure ("Incorrectly parsed: "<> show a)
             Failure _ -> assertFailure "Should have parsed an RC"
             CompletionInvoked _ -> assertFailure "Incorrectly triggered completion"

--- a/test/ConfCrypt/Commands/Tests.hs
+++ b/test/ConfCrypt/Commands/Tests.hs
@@ -106,7 +106,6 @@ readTests = testGroup "Read" [
         case res of
             Left e ->
                 e @=? FormatParseError "1:6:\n  |\n1 | foo%abar\n  |      ^\nUnrecognized variable a\n"
-                -- This is ugly, but it can't be improved without revamping error message formatting in general
             Right _ ->
                 assertFailure "Invalid format didn't throw an error"
 

--- a/test/ConfCrypt/Commands/Tests.hs
+++ b/test/ConfCrypt/Commands/Tests.hs
@@ -105,7 +105,8 @@ readTests = testGroup "Read" [
         res <- getReadResult (Just "foo%abar") testLines
         case res of
             Left e ->
-                e @=? FormatParseError "Invalid format: unrecognized variable \"a\" at column 8 in \"foo%abar\""
+                e @=? FormatParseError "1:6:\n  |\n1 | foo%abar\n  |      ^\nUnrecognized variable a\n"
+                -- This is ugly, but it can't be improved without revamping error message formatting in general
             Right _ ->
                 assertFailure "Invalid format didn't throw an error"
 

--- a/test/ConfCrypt/Commands/Tests.hs
+++ b/test/ConfCrypt/Commands/Tests.hs
@@ -75,7 +75,7 @@ readTests :: TestTree
 readTests = testGroup "Read" [
     testCase "reading produces decrypted results" $ do
         let testLines = parseConfCrypt "test file" testFile
-        res <- getReadResult testLines
+        res <- getReadResult Nothing testLines
         case res of
             Left e ->
                 assertFailure $ show e
@@ -84,23 +84,41 @@ readTests = testGroup "Read" [
 
    ,testCase "reading an empty file is an empty file" $ do
         let testLines = parseConfCrypt "empty test file" "# just a comment"
-        res <- getReadResult testLines
+        res <- getReadResult Nothing testLines
         case res of
             Left e ->
                 assertFailure $ show e
             Right lines ->
                 lines @=? []
 
+    ,testCase "user-specified formats are used to render output" $ do
+        let testLines = parseConfCrypt "test file" testFile
+        res <- getReadResult (Just "foo%t %n=%v %%") testLines
+        case res of
+            Left e ->
+                assertFailure $ show e
+            Right lines ->
+                lines @=? ["fooString Test=Foobar %", "fooInt Test2=42 %"]
+
+    ,testCase "invalid formats give an error" $ do
+        let testLines = parseConfCrypt "test file" testFile
+        res <- getReadResult (Just "foo%abar") testLines
+        case res of
+            Left e ->
+                e @=? FormatParseError "Invalid format: unrecognized variable \"a\" at column 8 in \"foo%abar\""
+            Right _ ->
+                assertFailure "Invalid format didn't throw an error"
+
     -- TODO implement the 'Arbitrary' instance to make this rule possible
    -- ,testProperty "read . encrypt . read == id" $ \x -> x == 0
     ]
     where
-        getReadResult :: Either ConfCryptError ConfCryptFile -> IO (Either ConfCryptError [T.Text])
-        getReadResult testLines = do
+        getReadResult :: Maybe T.Text -> Either ConfCryptError ConfCryptFile -> IO (Either ConfCryptError [T.Text])
+        getReadResult tpl testLines = do
             probablyKP <- runExceptT $ unpackPrivateRSAKey dangerousTestKey
             privateKey <- either (assertFailure . show) (pure . project ) probablyKP :: IO RSA.PrivateKey
             ccf <- either (assertFailure . show) pure testLines
-            runResourceT . runExceptT $ runReaderT (evaluate $ ReadConfCrypt Nothing) (ccf, TextKey privateKey) :: IO (Either ConfCryptError [T.Text])
+            runResourceT . runExceptT $ runReaderT (evaluate $ ReadConfCrypt tpl) (ccf, TextKey privateKey) :: IO (Either ConfCryptError [T.Text])
 
 
 addTests :: TestTree

--- a/test/ConfCrypt/Commands/Tests.hs
+++ b/test/ConfCrypt/Commands/Tests.hs
@@ -100,7 +100,7 @@ readTests = testGroup "Read" [
             probablyKP <- runExceptT $ unpackPrivateRSAKey dangerousTestKey
             privateKey <- either (assertFailure . show) (pure . project ) probablyKP :: IO RSA.PrivateKey
             ccf <- either (assertFailure . show) pure testLines
-            runResourceT . runExceptT $ runReaderT (evaluate ReadConfCrypt) (ccf, TextKey privateKey) :: IO (Either ConfCryptError [T.Text])
+            runResourceT . runExceptT $ runReaderT (evaluate $ ReadConfCrypt Nothing) (ccf, TextKey privateKey) :: IO (Either ConfCryptError [T.Text])
 
 
 addTests :: TestTree

--- a/test/ConfCrypt/Template/Tests.hs
+++ b/test/ConfCrypt/Template/Tests.hs
@@ -1,0 +1,37 @@
+module ConfCrypt.Template.Tests (
+    templateTests
+    ) where
+
+import ConfCrypt.Template (renderTemplate)
+import ConfCrypt.Types (Parameter(..), SchemaType(..))
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Data.Text (Text(..))
+import Data.Either (isLeft)
+
+templateTests :: TestTree
+templateTests = testGroup "format template parser" [
+    testCase "basic template works" $ 
+        render "%t %n %v" param @=? Right "String name value"
+    
+    ,testCase "template variables can appear next to any character" $ 
+        render "tt%ttt%ntt%vtt" param @=? Right "ttStringttnamettvaluett"
+    
+    ,testCase "invalid variable names give an error" $
+        isLeft (render "%t %a" param) @=? True
+    
+    ,testCase "%% renders to %" $
+        render "%v%%%n%%%t" param @=? Right "value%name%String"
+    
+    ,testCase "variables can appear more than once" $
+        render "%v%v%v" param @=? Right "valuevaluevalue"
+    ]
+
+render :: Text -> Parameter -> Either Text Text
+render tpl param =
+    let renderFunc = renderTemplate tpl
+    in renderFunc <*> pure param
+
+param = Parameter "name" "value" (Just CString)

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -2,6 +2,7 @@ import ConfCrypt.Parser.Tests (parserTests)
 import ConfCrypt.Commands.Tests (commandTests)
 import ConfCrypt.Encryption.Tests (encryptionTests)
 import ConfCrypt.CLI.API.Tests (cliAPITests)
+import ConfCrypt.Template.Tests (templateTests)
 import Test.Tasty (TestTree, defaultMain, testGroup)
 
 main :: IO ()
@@ -19,5 +20,6 @@ libraryTests :: TestTree
 libraryTests = testGroup "all library tests"[
     parserTests,
     commandTests,
-    encryptionTests
+    encryptionTests,
+    templateTests
     ]


### PR DESCRIPTION
This allows users to specify their own output format, making confcrypt's
output more easily machine-parseable.

The code probably isn't very pretty, so please don't pull any punches in reviews 😄 