### PR TITLE
Support Inplace edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,20 @@ brew cask install confcrypt
     `confcrypt rsa read --key <filename> <filename>`
     This command reads in the provided file, decrypts the configuration variables using the provided key, then prints them to stdout. This allows you to pipe the results to other utilities. Returns 0 on success.
 - add a parameter
-    `confcrypt rsa add --key <filename> --name <String> --type <SchemaType> --vaue <String> <filename>
-    Adds a new confguration parameter to the file. `--name` and `--value` are required, while `--type` is optional. If `--type` is provided, the schema record will be added immediately before the config variable. In total this adds two lines to the file. Returns 0 on sccess.
+    `confcrypt rsa add --key <filename> --name <String> --type <SchemaType> --vaue <String> --in-place <filename>
+    Adds a new confguration parameter to the file. `--name` and `--value` are required, while `--type` and `--in-place`are optional.
+    If `--type` is provided, the schema record will be added immediately before the config variable.
+    `--in-place` toggles whether to overwrite the provided file or emit the results to stdout.
+    In total this adds two lines to the file. Returns 0 on sccess.
 - remove a parameter
-    `confcrypt delete --name <filename>`
+    `confcrypt delete --name <String> --in-place <filename>`
     Removes an existing config parameter & associated schema. Returns 0 on success or 1 if the parameter is not found in the file.
+    `--in-place` toggles whether to overwrite the provided file or emit the results to stdout.
 - edit a parameter in-place
-    `confcrypt rsa edit --key <filename> --name <String> --value <String> --type <SchemaType> <filename>`
-    Modifies an existing configuration parameter in place, leaving all other lines unchanged. While this isn't how it's actually implemented, this operation is equivalent to piping `confcrypt read` to a new file, editing the parameter, then reencrypting it.
+    `confcrypt rsa edit --key <filename> --name <String> --value <String> --type <SchemaType> --in-place <filename>`
+    Modifies an existing configuration parameter in place, leaving all other lines unchanged.
+    While this isn't how it's actually implemented, this operation is equivalent to piping `confcrypt read` to a new file, editing the parameter, then reencrypting it.
+    `--in-place` toggles whether to overwrite the provided file or emit the results to stdout.
 - validate a config
     `confcrypt rsa validate --key <filename> <filename>`
     Checks that each config parameter matches the type of its schema. All errors are accumulated and returned at the end, with a response code equal to the number of failures.

--- a/app/ConfCrypt/CLI/Engine.hs
+++ b/app/ConfCrypt/CLI/Engine.hs
@@ -54,9 +54,9 @@ run parsedArguments = do
 
                 -- Requires Decryption
                 RC KeyAndConf {key, provider} cmd ->
-                        runConfCrypt parsedConfiguration $ runWithDecrypt key provider cmd
+                    runConfCrypt parsedConfiguration $ runWithDecrypt key provider cmd
                 GC KeyAndConf {key, provider} cmd ->
-                        runConfCrypt parsedConfiguration $ runWithDecrypt key provider cmd
+                    runConfCrypt parsedConfiguration $ runWithDecrypt key provider cmd
                 VC KeyAndConf {key, provider} ->
                     runConfCrypt parsedConfiguration $ runWithDecrypt key provider ValidateConfCrypt
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -15,7 +15,7 @@ main = do
     (results, outputPath) <- run parsedArguments
     case outputPath of
         Nothing -> traverse_ (putStrLn . unpack) results
-        Just fp -> T.writeFile fp $ (T.intercalate "\n" results) <> "\n"
+        Just fp -> T.writeFile fp $ T.intercalate "\n" results <> "\n"
     -- The ^ `putStrLn` call is important to preserve the trailing newline. Consider
     -- moving this into the library to make the code read more clearly.
     -- There's no reason that `writeFullContentsToBuffer` can't tag each line with a trailing newline

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,13 +5,17 @@ import ConfCrypt.CLI.API (cliParser)
 import System.Environment (getArgs)
 import Data.Foldable (traverse_)
 import Data.Text (Text, intercalate, unpack)
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
 import Options.Applicative (customExecParser, ParserPrefs, prefs, showHelpOnEmpty)
 
 main :: IO ()
 main = do
     parsedArguments <- customExecParser (prefs showHelpOnEmpty) cliParser
-    results <- run parsedArguments
-    traverse_ (putStrLn . unpack) results
+    (results, outputPath) <- run parsedArguments
+    case outputPath of
+        Nothing -> traverse_ (putStrLn . unpack) results
+        Just fp -> T.writeFile fp $ (T.intercalate "\n" results) <> "\n"
     -- The ^ `putStrLn` call is important to preserve the trailing newline. Consider
     -- moving this into the library to make the code read more clearly.
     -- There's no reason that `writeFullContentsToBuffer` can't tag each line with a trailing newline

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                confcrypt
-version:             0.2.3.3
+version:             0.2.4.0
 github:              collegevine/confcrypt
 license:             MIT
 author:              "Chris Coffey"

--- a/test/ConfCrypt/CLI/API/Tests.hs
+++ b/test/ConfCrypt/CLI/API/Tests.hs
@@ -152,7 +152,7 @@ addCases = testGroup "add" [
         let args =  ["rsa", "add", "--key", "testKey", "--name", "test", "--type", "String", "--value", "foo", "test.econf"]
             res = execParserPure defaultPrefs cliParser args
         case res of
-            Success (AC (KeyAndConf (OnDisk "testKey") LocalRSA "test.econf") (AddConfCrypt "test" "foo" CString)) -> assertBool "can't fail" True
+            Success (AC (KeyAndConf (OnDisk "testKey") LocalRSA "test.econf") (AddConfCrypt "test" "foo" CString) StdOut) -> assertBool "can't fail" True
             Success a -> assertFailure ("Incorrectly parsed: "<> show a)
             Failure _ -> assertFailure "Should have parsed an AC"
             CompletionInvoked _ -> assertFailure "Incorrectly triggered completion"
@@ -161,7 +161,7 @@ addCases = testGroup "add" [
         let args =  ["rsa", "add", "-k", "testKey", "-n", "test", "-t", "String", "-v", "foo", "test.econf"]
             res = execParserPure defaultPrefs cliParser args
         case res of
-            Success (AC (KeyAndConf (OnDisk "testKey") LocalRSA "test.econf") (AddConfCrypt "test" "foo" CString)) -> assertBool "can't fail" True
+            Success (AC (KeyAndConf (OnDisk "testKey") LocalRSA "test.econf") (AddConfCrypt "test" "foo" CString) StdOut) -> assertBool "can't fail" True
             Success a -> assertFailure ("Incorrectly parsed: "<> show a)
             Failure _ -> assertFailure "Should have parsed an AC"
             CompletionInvoked _ -> assertFailure "Incorrectly triggered completion"
@@ -213,7 +213,7 @@ editCases = testGroup "edit" [
         let args =  ["rsa", "edit", "--key", "testKey", "--name", "test", "--type", "String", "--value", "foo", "test.econf"]
             res = execParserPure defaultPrefs cliParser args
         case res of
-            Success (EC (KeyAndConf (OnDisk "testKey") LocalRSA "test.econf") (EditConfCrypt "test" "foo" CString)) -> assertBool "can't fail" True
+            Success (EC (KeyAndConf (OnDisk "testKey") LocalRSA "test.econf") (EditConfCrypt "test" "foo" CString) StdOut) -> assertBool "can't fail" True
             Success a -> assertFailure ("Incorrectly parsed: "<> show a)
             Failure _ -> assertFailure "Should have parsed an AC"
             CompletionInvoked _ -> assertFailure "Incorrectly triggered completion"
@@ -222,7 +222,7 @@ editCases = testGroup "edit" [
         let args =  ["rsa", "edit", "-k", "testKey", "-n", "test", "-t", "String", "-v", "foo", "test.econf"]
             res = execParserPure defaultPrefs cliParser args
         case res of
-            Success (EC (KeyAndConf (OnDisk "testKey") LocalRSA "test.econf") (EditConfCrypt "test" "foo" CString)) -> assertBool "can't fail" True
+            Success (EC (KeyAndConf (OnDisk "testKey") LocalRSA "test.econf") (EditConfCrypt "test" "foo" CString) StdOut) -> assertBool "can't fail" True
             Success a -> assertFailure ("Incorrectly parsed: "<> show a)
             Failure _ -> assertFailure "Should have parsed an AC"
             CompletionInvoked _ -> assertFailure "Incorrectly triggered completion"
@@ -250,7 +250,7 @@ deleteCases = testGroup "delete" [
         let args =  ["delete", "--name", "test", "test.econf"]
             res = execParserPure defaultPrefs cliParser args
         case res of
-            Success (DC (Conf "test.econf") (DeleteConfCrypt "test")) -> assertBool "can't fail" True
+            Success (DC (Conf "test.econf") (DeleteConfCrypt "test") StdOut) -> assertBool "can't fail" True
             Success a -> assertFailure ("Incorrectly parsed: "<> show a)
             Failure _ -> assertFailure "Should have parsed a DC"
             CompletionInvoked _ -> assertFailure "Incorrectly triggered completion"
@@ -259,7 +259,7 @@ deleteCases = testGroup "delete" [
         let args =  ["delete", "-n", "test", "test.econf"]
             res = execParserPure defaultPrefs cliParser args
         case res of
-            Success (DC (Conf "test.econf") (DeleteConfCrypt "test")) -> assertBool "can't fail" True
+            Success (DC (Conf "test.econf") (DeleteConfCrypt "test") StdOut) -> assertBool "can't fail" True
             Success a -> assertFailure ("Incorrectly parsed: "<> show a)
             Failure _ -> assertFailure "Should have parsed a DC"
             CompletionInvoked _ -> assertFailure "Incorrectly triggered completion"


### PR DESCRIPTION
this addresses #31 , as described by @gasi . The flag is available for the three mutation operations: `add`, `edit`, and `delete`. The default behavior for any command is to emit the results to stdout, but this in-place option simplifies actually working with the config file (no more indirection through a variable).
