### PR TITLE
Readme format cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ brew cask install confcrypt
 2. At the root of this repo, run `stack install`.  (Takes 10-15 minutes.)
 
 ## Using confcrypt
-- create a config
+- **create a config**    
     `confcrypt create <filename>` creates a new empty confcrypt config named `<filename>.econf`. Internally, it looks like this:
     ```
     # confcrypt schema
@@ -36,52 +36,52 @@ brew cask install confcrypt
     # TIMEOUT_MS : Int
     # TIMEOUT_MS = 300
     ```
-- read a config
-    `confcrypt rsa read --key <filename> <filename>`
+- **read a config**    
+    `confcrypt rsa read --key <filename> <filename>`    
     This command reads in the provided file, decrypts the configuration variables using the provided key, then prints them to stdout. This allows you to pipe the results to other utilities. Returns 0 on success.
-- add a parameter
-    `confcrypt rsa add --key <filename> --name <String> --type <SchemaType> --vaue <String> --in-place <filename>
-    Adds a new confguration parameter to the file. `--name` and `--value` are required, while `--type` and `--in-place`are optional.
+- **add a parameter**    
+    `confcrypt rsa add --key <filename> --name <String> --type <SchemaType> --vaue <String> --in-place <filename>`    
+    Adds a new confguration parameter to the file. `--name` and `--value` are required, while `--type` and `--in-place`are optional.    
     If `--type` is provided, the schema record will be added immediately before the config variable.
     `--in-place` toggles whether to overwrite the provided file or emit the results to stdout.
     In total this adds two lines to the file. Returns 0 on sccess.
-- remove a parameter
-    `confcrypt delete --name <String> --in-place <filename>`
-    Removes an existing config parameter & associated schema. Returns 0 on success or 1 if the parameter is not found in the file.
+- **remove a parameter**    
+    `confcrypt delete --name <String> --in-place <filename>`    
+    Removes an existing config parameter & associated schema. Returns 0 on success or 1 if the parameter is not found in the file.    
     `--in-place` toggles whether to overwrite the provided file or emit the results to stdout.
-- edit a parameter in-place
-    `confcrypt rsa edit --key <filename> --name <String> --value <String> --type <SchemaType> --in-place <filename>`
-    Modifies an existing configuration parameter in place, leaving all other lines unchanged.
+- **edit a parameter in-place**    
+    `confcrypt rsa edit --key <filename> --name <String> --value <String> --type <SchemaType> --in-place <filename>`    
+    Modifies an existing configuration parameter in place, leaving all other lines unchanged.    
     While this isn't how it's actually implemented, this operation is equivalent to piping `confcrypt read` to a new file, editing the parameter, then reencrypting it.
     `--in-place` toggles whether to overwrite the provided file or emit the results to stdout.
-- validate a config
-    `confcrypt rsa validate --key <filename> <filename>`
+- **validate a config**    
+    `confcrypt rsa validate --key <filename> <filename>`    
     Checks that each config parameter matches the type of its schema. All errors are accumulated and returned at the end, with a response code equal to the number of failures.
 
-- Using Amazon KMS instead of a local key
+- **Using Amazon KMS instead of a local key**    
     The `rsa` command tree exists under `aws`, which changes the behavior of the `--key` parameter to represent a KMS key id rather than an on-disk rsa key file. The otherwise the semantics of the commands are identical between `rsa` and `kms` branches.
 
 ## The confcrypt file format
-    ```
-    # confcrypt schema
-    # Configuration parameters may be either a String, Int, or Boolean
-    # Parameter schema take the following shape:
-    # schema := [term | value | comment]
-    #   term := confname : type
-    #   confname := [a-z,A-Z,_,0-9]
-    #   type := String | Int | Boolean
-    #   value := confname = String
-    #   comment := # String
-    #
-    # For example:
-    # DB_CONN_STR : String
-    # DB_CONN_STR = Connection String
-    # USE_SSL : Boolean
-    # USE_SSL = True
-    # TIMEOUT_MS : Int
-    # TIMEOUT_MS = 300
-    ```
+```
+# confcrypt schema
+# Configuration parameters may be either a String, Int, or Boolean
+# Parameter schema take the following shape:
+# schema := [term | value | comment]
+#   term := confname : type
+#   confname := [a-z,A-Z,_,0-9]
+#   type := String | Int | Boolean
+#   value := confname = String
+#   comment := # String
+#
+# For example:
+# DB_CONN_STR : String
+# DB_CONN_STR = Connection String
+# USE_SSL : Boolean
+# USE_SSL = True
+# TIMEOUT_MS : Int
+# TIMEOUT_MS = 300
+```
 
-    *Note* confcrypt files must end with a trailing newline.
+*Note:* confcrypt files must end with a trailing newline.    
 
-    While the default config created via `confcrypt new ...` places the schema on line `n` and parameters on `n+1`, there's no required ordering for the file. In fact, you can choose to entirely omit the schema and only store configuration paraemters in an `econf` file, but this will cause `confcrypt validate` to fail.
+While the default config created via `confcrypt new ...` places the schema on line `n` and parameters on `n+1`, there's no required ordering for the file. In fact, you can choose to entirely omit the schema and only store configuration paraemters in an `econf` file, but this will cause `confcrypt validate` to fail.


### PR DESCRIPTION
Cleans up the format of the readme, providing greater visual contrast in the "Using confcrypt" section, and fixing other formatting issues.