### PR TITLE
Remove cask from brew install line

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ As soon as an application is deployed or built on more than a single machine, yo
 #### Mac OSX via Brew
 ```
 brew tap collegevine/brew
-brew cask install confcrypt
+brew install confcrypt
 ```
 #### Windows, Linux, & OSX native
 


### PR DESCRIPTION
I was going through the process of installing confcrypt and was getting errors. After troubleshooting, I came across a nugget of info online that cask is no longer a thing and we can just use `brew install confcrypt` here - worked for me!

![image](https://user-images.githubusercontent.com/51382621/132573494-d45460dc-6902-46fd-b4ed-6694e31412f1.png)
