### PR TITLE
Update stack.yaml to handle Mac M1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ brew install confcrypt
 
 1. If you don't have Haskell installed and working already, you'll need it.  Install `stack` from [haskellstack.org](https://haskellstack.org/).
 2. At the root of this repo, run `stack install`.  (Takes 10-15 minutes.)
-    - If you're on an M1 Mac, you may need to run `stack install --arch x86_64` and enable Rosetta when prompted to.
-
 
 ## Using confcrypt
 - **create a config**

--- a/stack.yaml
+++ b/stack.yaml
@@ -56,8 +56,8 @@ extra-deps:
 # require-stack-version: ">=1.7"
 #
 # Override the architecture used by stack, especially useful on Windows
-# arch: i386
-# arch: x86_64
+# In combination with Rosetta, works on newer Mac M1 models.
+arch: x86_64
 #
 # Extra directories used by stack for building
 # extra-include-dirs: [/path/to/dir]


### PR DESCRIPTION
Addendum to #42 . Realized we could move the `--arch` flag directly into the repo's configuration.

I'm 99% positive that this change will continue to work for windows, linux, but would someone else be able to test & confirm?